### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Windows
 `C:\Program Files\Inductive Automation\Ignition\data\ignition.conf`
 
 Linux  
-`\var\lib\ignition\data\ignition.conf`
+`/usr/local/bin/ignition/data/ignition.conf`
 
 Add an additonal Java parameter in the 'Java Additional Parameters' section below the first parameter:
 


### PR DESCRIPTION
I have Ignition 8.1 maker version installed in a Linux Ubuntu 20.04 environment and the 'ignition.conf' file is not in the location indicated in this readme. I provided the new location from my system.